### PR TITLE
Fix certificate parsing crash on Linux

### DIFF
--- a/src/GeeSuthSoft.KSA.ZATCA/Generators/GeneratorInvoice.cs
+++ b/src/GeeSuthSoft.KSA.ZATCA/Generators/GeneratorInvoice.cs
@@ -32,7 +32,7 @@ namespace GeeSuthSoft.KSA.ZATCA.Generators
             //if (InvoiceObject.InvoiceTypeCode.Name.StartsWith("02"))
             //{
 
-                byte[] certificateBytes = Encoding.UTF8.GetBytes(X509CertificateContent);
+                byte[] certificateBytes = Convert.FromBase64String(X509CertificateContent);
                 X509Certificate2 parsedCertificate = new(certificateBytes);
 
                 string SignatureTimestamp = DateTime.Now.ToString("yyyy-MM-dd'T'HH:mm:ss");


### PR DESCRIPTION
### Description:
X509CertificateContent was in base64 DER format 

X509Certificate2 was receiving UTF8-encoded bytes of a Base64 string instead of the actual decoded DER binary. Windows was lenient about this but OpenSSL on Linux rejected it with an ASN1 error.
Changed Encoding.UTF8.GetBytes() to Convert.FromBase64String() to pass proper DER bytes directly.


### Verification:

i ran the `SignInvoiceTest.GenerateSignedInvoiceTestAsync` unit test successfully